### PR TITLE
RIVM-145 IPv6 multicast fix as a regression from v0.4.7.8 when peer could not recognize other peers correctly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,8 +24,8 @@ require gerace.dev/zipfs v0.2.0
 
 require (
 	github.com/slonm/tableprinter v0.0.0-20230107100804-643098716018
-	github.com/vikulin/anet v0.0.6-0.20240829153812-99b8955b2cff
 	github.com/vorot93/golang-signals v0.0.0-20170221070717-d9e83421ce45
+	github.com/wlynxg/anet v0.0.4
 	golang.org/x/exp v0.0.0-20221217163422-3c43f8badb15
 	golang.zx2c4.com/wintun v0.0.0-20211104114900-415007cec224
 )

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,6 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
-github.com/vikulin/anet v0.0.6-0.20240829153812-99b8955b2cff h1:iifW98BSWU92RJmWRcnruOihGZphu1YYBlWA0zLG7zs=
-github.com/vikulin/anet v0.0.6-0.20240829153812-99b8955b2cff/go.mod h1:4hyB1C384gHwcoCRaXPrCy90R0JK1AlK/a0kH+BrPyQ=
 github.com/vikulin/sctp v0.0.0-20221009200520-ae0f2830e422 h1:KJn6ovcNlavPTgdK2uKJoonWPP3GTb8x4FyYPIrwpZw=
 github.com/vikulin/sctp v0.0.0-20221009200520-ae0f2830e422/go.mod h1:wbWp47D/qXkQrDuO8qSeUXdLN9qXNZzIgLGDQIoJlJU=
 github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
@@ -79,6 +77,8 @@ github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f h1:p4VB7kIXpOQvV
 github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vorot93/golang-signals v0.0.0-20170221070717-d9e83421ce45 h1:hB/hkjwf3BQnZE6Wk3SBwMJz0NqnGdwXoNzHVSYb0N0=
 github.com/vorot93/golang-signals v0.0.0-20170221070717-d9e83421ce45/go.mod h1:dfjQkJsG5auteUbnfLIcU72Y/z8tj7DuW9fik8f2Zn0=
+github.com/wlynxg/anet v0.0.4 h1:0de1OFQxnNqAu+x2FAKKCVIrnfGKQbs7FQz++tB0+Uw=
+github.com/wlynxg/anet v0.0.4/go.mod h1:eay5PRQr7fIVAMbTbchTnO9gG65Hg/uYGdc7mguHxoA=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=

--- a/src/core/link_tcp.go
+++ b/src/core/link_tcp.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/vikulin/anet"
+	"github.com/wlynxg/anet"
 
 	"github.com/Arceliar/phony"
 )

--- a/src/multicast/multicast.go
+++ b/src/multicast/multicast.go
@@ -9,10 +9,9 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"strconv"
 	"time"
 
-	"github.com/vikulin/anet"
+	"github.com/wlynxg/anet"
 
 	"github.com/Arceliar/phony"
 	"github.com/gologme/log"
@@ -406,11 +405,16 @@ func (m *Multicast) listen() {
 		phony.Block(m, func() {
 			interfaces = m._interfaces
 		})
-		zone, err := strconv.Atoi(from.Zone)
-		if err != nil {
-			continue
+		var inter interfaceInfo
+		var ok = false
+		for _, info := range interfaces {
+			if info.iface.Name == from.Zone {
+				inter = *info
+				ok = true
+			}
 		}
-		if info, ok := interfaces[zone]; ok && info.listen {
+		info := inter
+		if ok && info.listen {
 			addr.Zone = ""
 			pin := fmt.Sprintf("/?key=%s&priority=%d", hex.EncodeToString(key), info.priority)
 			u, err := url.Parse("tls://" + addr.String() + pin)


### PR DESCRIPTION
RIVM-145 IPv6 multicast fix as a regression from v0.4.7.8 when peer could not recognize other peers correctly

